### PR TITLE
增加actions手动触发按钮，python修改为3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - main
   schedule:
     - cron: '5 16,22 * * *'
+  workflow_dispatch:
 
 jobs:
   tieba_sign:
@@ -16,7 +17,7 @@ jobs:
       - name: 'Set python'
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: 'Install dependencies'
         run: python -m pip install --upgrade requests
       - name: 'Start Sign'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 'Set python'
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: 'Install dependencies'
         run: python -m pip install --upgrade requests
       - name: 'Start Sign'


### PR DESCRIPTION
1、给Workflow增加手动的执行按钮，不再需要通过提交commit来触发actions执行。
![_20230105093821](https://user-images.githubusercontent.com/7272911/210682067-4e2983b1-c8a1-40ca-af74-441d7b777c6f.png)
2、原python3.6环境执行会报错，github actions不再支持3.6了，更改为3.8环境。（测试3.10可以正常工作，改成直接一步到位到3.10好了，省的又出现没多久3.8用不了的尴尬）
