### PR TITLE
fix(main.yml): 将不再受支持的Python 3.6升级到3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 'Set python'
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
       - name: 'Install dependencies'
         run: python -m pip install --upgrade requests
       - name: 'Start Sign'


### PR DESCRIPTION
使用原3.6运行工作流时会失败，改为3.7后正常